### PR TITLE
Fixes #10

### DIFF
--- a/OpenSim/Framework/LandData.cs
+++ b/OpenSim/Framework/LandData.cs
@@ -84,7 +84,7 @@ namespace OpenSim.Framework
         private UUID _snapshotID = UUID.Zero;
         private Vector3 _userLocation = new();
         private Vector3 _userLookAt = new();
-        private int _otherCleanTime = 300;
+        private int _otherCleanTime = 5;
         private string _mediaType = "none/none";
         private string _mediaDescription = "";
         private int _mediaHeight = 0;

--- a/OpenSim/Region/Application/OpenSim.cs
+++ b/OpenSim/Region/Application/OpenSim.cs
@@ -299,7 +299,7 @@ namespace OpenSim
                                             + "  --mergeReplaceObjects if scene as a object with same id, replace it\n"
                                             + "       without this option, skip loading that object\n"
                                             + "--skip-assets will load the OAR but ignore the assets it contains.\n"
-                                            + "--default-user will use this user for any objects with an owner whose UUID is not found in the grid.\n"
+                                            + "--default-user will use this user for any objects and parcels with an owner whose UUID is not found in the grid.\n"
                                             + "--no-objects suppresses the addition of any objects (good for loading only the terrain).\n"
                                             + "--rotation specified rotation to be applied to the oar. Specified in degrees.\n"
                                             + "--bounding-origin will only place objects that after displacement and rotation fall within the bounding cube who's position starts at <x,y,z>. Defaults to <0,0,0>.\n"

--- a/OpenSim/Region/CoreModules/World/Archiver/ArchiveReadRequest.cs
+++ b/OpenSim/Region/CoreModules/World/Archiver/ArchiveReadRequest.cs
@@ -925,7 +925,7 @@ namespace OpenSim.Region.CoreModules.World.Archiver
                 {
                     if (parcel.GroupID.IsZero())
                     {
-                        parcel.OwnerID = m_rootScene.RegionInfo.EstateSettings.EstateOwner;
+                        parcel.OwnerID = m_defaultUser;
                         parcel.IsGroupOwned = false;
                     }
                     else
@@ -937,7 +937,7 @@ namespace OpenSim.Region.CoreModules.World.Archiver
                 else
                 {
                     if (!ResolveUserUuid(scene, parcel.OwnerID))
-                        parcel.OwnerID = m_rootScene.RegionInfo.EstateSettings.EstateOwner;
+                        parcel.OwnerID = m_defaultUser;
                 }
 
                 List<LandAccessEntry> accessList = new();

--- a/OpenSim/Region/CoreModules/World/Land/LandManagementModule.cs
+++ b/OpenSim/Region/CoreModules/World/Land/LandManagementModule.cs
@@ -1693,7 +1693,9 @@ namespace OpenSim.Region.CoreModules.World.Land
                 land.LandData.OwnerID = m_scene.RegionInfo.EstateSettings.EstateOwner;
                 land.LandData.GroupID = UUID.Zero;
                 land.LandData.IsGroupOwned = false;
-                land.LandData.Flags &= ~(uint) (ParcelFlags.ForSale | ParcelFlags.ForSaleObjects | ParcelFlags.SellParcelObjects | ParcelFlags.ShowDirectory);
+                land.LandData.Flags &= ~(uint) (ParcelFlags.ForSale | ParcelFlags.ForSaleObjects | ParcelFlags.SellParcelObjects | ParcelFlags.ShowDirectory | ParcelFlags.CreateObjects);
+                land.LandData.Name = "Abandoned Land";
+                land.LandData.OtherCleanTime = 5;
 
                 UpdateLandObject(land.LandData.LocalID, land.LandData);
                 m_scene.ForEachClient(SendParcelOverlay);
@@ -1721,7 +1723,9 @@ namespace OpenSim.Region.CoreModules.World.Land
                 land.LandData.SeeAVs = true;
                 land.LandData.AnyAVSounds = true;
                 land.LandData.GroupAVSounds = true;
-                land.LandData.Flags &= ~(uint) (ParcelFlags.ForSale | ParcelFlags.ForSaleObjects | ParcelFlags.SellParcelObjects | ParcelFlags.ShowDirectory);
+                land.LandData.Flags &= ~(uint) (ParcelFlags.ForSale | ParcelFlags.ForSaleObjects | ParcelFlags.SellParcelObjects | ParcelFlags.ShowDirectory | ParcelFlags.CreateObjects);
+                land.LandData.Name = "Reclaimed Land";
+                land.LandData.OtherCleanTime = 5;
                 UpdateLandObject(land.LandData.LocalID, land.LandData);
                 m_scene.ForEachClient(SendParcelOverlay);
                 land.SendLandUpdateToAvatars();


### PR DESCRIPTION
- If default-user is specified, make them own the parcels as well instead of the estate owner when a user is not found
- Autoreturn should be in minutes, changed from 300 to 5
- Abandoned and reclaimed parcels should also default to safe settings
- Abandoned and reclaimed parcels are now named "Abandoned Land" and "Reclaimed Land"