### PR TITLE
Fixes #14

### DIFF
--- a/OpenSim/Region/CoreModules/Avatar/Attachments/AttachmentsModule.cs
+++ b/OpenSim/Region/CoreModules/Avatar/Attachments/AttachmentsModule.cs
@@ -381,7 +381,7 @@ namespace OpenSim.Region.CoreModules.Avatar.Attachments
                 ad.AttachmentObjectStates = null;
 
                 if (attachments.Count > 0)
-                    m_scene.IncomingAttechments(sp, attachments);
+                    m_scene.IncomingAttachments(sp, attachments);
                 else
                     sp.GotAttachmentsData = true;
             }

--- a/OpenSim/Region/CoreModules/Framework/EntityTransfer/EntityTransferModule.cs
+++ b/OpenSim/Region/CoreModules/Framework/EntityTransfer/EntityTransferModule.cs
@@ -1313,6 +1313,13 @@ namespace OpenSim.Region.CoreModules.Framework.EntityTransfer
 
         protected virtual bool CreateAgent(ScenePresence sp, GridRegion reg, GridRegion finalDestination, AgentCircuitData agentCircuit, uint teleportFlags, EntityTransferContext ctx, out string reason, out bool logout)
         {
+            if (sp.GotAttachmentsData == false)
+            {
+                logout = false;
+                reason = "Cannot leave region yet, attachments are still loading";
+                return false;
+            }
+
             GridRegion source = new(m_sceneRegionInfo)
             {
                 RawServerURI = m_thisGridInfo.GateKeeperURL

--- a/OpenSim/Region/CoreModules/Framework/EntityTransfer/HGEntityTransferModule.cs
+++ b/OpenSim/Region/CoreModules/Framework/EntityTransfer/HGEntityTransferModule.cs
@@ -258,6 +258,14 @@ namespace OpenSim.Region.CoreModules.Framework.EntityTransfer
         protected override bool CreateAgent(ScenePresence sp, GridRegion reg, GridRegion finalDestination, AgentCircuitData agentCircuit, uint teleportFlags, EntityTransferContext ctx, out string reason, out bool logout)
         {
             m_log.DebugFormat("[HG ENTITY TRANSFER MODULE]: CreateAgent {0} {1}", reg.ServerURI, finalDestination.ServerURI);
+
+            if (sp.GotAttachmentsData == false)
+            {
+                logout = false;
+                reason = "Cannot leave region yet, attachments are still loading";
+                return false;
+            }
+
             reason = string.Empty;
             logout = false;
             int flags = Scene.GridService.GetRegionFlags(m_sceneRegionInfo.ScopeID, reg.RegionID);
@@ -898,13 +906,13 @@ namespace OpenSim.Region.CoreModules.Framework.EntityTransfer
                                 defsp = null;
                                 uuidGatherer = null;
                                 toadd = null;
+                                sp.GotAttachmentsData = true;
                             },
                             OwnerID.ToString());
                     }
                 }
             }
 
-            sp.GotAttachmentsData = true;
             return true;
         }
 

--- a/OpenSim/Region/Framework/Scenes/Scene.cs
+++ b/OpenSim/Region/Framework/Scenes/Scene.cs
@@ -2932,7 +2932,7 @@ namespace OpenSim.Region.Framework.Scenes
             return true;
         }
 
-        public bool IncomingAttechments(ScenePresence sp, List<SceneObjectGroup> attachments)
+        public bool IncomingAttachments(ScenePresence sp, List<SceneObjectGroup> attachments)
         {
             //m_log.DebugFormat(" >>> IncomingCreateObject(sog) <<< {0} deleted? {1} isAttach? {2}", ((SceneObjectGroup)sog).AbsolutePosition,
             //    ((SceneObjectGroup)sog).IsDeleted, ((SceneObjectGroup)sog).RootPart.IsAttachment);


### PR DESCRIPTION
This fixes the agent's scripts breaking when teleporting right after having landed, before attachments got loaded.